### PR TITLE
Feat: Implement platform image selection from TheGamesDB

### DIFF
--- a/components/PlatformForm.tsx
+++ b/components/PlatformForm.tsx
@@ -1,6 +1,6 @@
 
 import React, { useState, useEffect, useCallback } from 'react';
-import { Platform } from '../types';
+import { Platform, TheGamesDBImage, TheGamesDBPlatformImagesResponse } from '../types'; // Added TheGamesDBImage types
 import { Input } from './Input';
 import { Button } from './Button';
 import { Modal } from './Modal';
@@ -25,14 +25,17 @@ export const PlatformForm: React.FC<PlatformFormProps> = ({ isOpen, onClose, onS
   const [selectedTgdbPlatformId, setSelectedTgdbPlatformId] = useState<string>('');
   const [isLoadingTgdbPlatforms, setIsLoadingTgdbPlatforms] = useState(false);
   const [errorTgdbPlatforms, setErrorTgdbPlatforms] = useState<string | null>(null);
+  const [tgdbIconBaseUrl, setTgdbIconBaseUrl] = useState<string | null>(null); // Base URL for platform list icons
 
-  // Store the base URL for icons if provided by the API response
-  // For now, this is a placeholder. It would be populated if /api/thegamesdb/platforms returns it.
-  const [tgdbIconBaseUrl, setTgdbIconBaseUrl] = useState<string | null>(null);
+  // State for fetching specific platform images (fanart, banners, etc.)
+  const [platformImages, setPlatformImages] = useState<TheGamesDBImage[]>([]);
+  const [platformImagesBaseUrl, setPlatformImagesBaseUrl] = useState<string | null>(null);
+  const [isLoadingPlatformImages, setIsLoadingPlatformImages] = useState<boolean>(false);
+  const [errorPlatformImages, setErrorPlatformImages] = useState<string | null>(null);
 
 
   useEffect(() => {
-    if (isOpen && !initialPlatform) { // Only fetch for new platforms
+    if (isOpen && !initialPlatform) { // Only fetch for new platforms (the list of all platforms)
       setIsLoadingTgdbPlatforms(true);
       setErrorTgdbPlatforms(null);
       fetch('/api/thegamesdb/platforms')
@@ -77,8 +80,60 @@ export const PlatformForm: React.FC<PlatformFormProps> = ({ isOpen, onClose, onS
       // Reset for new platform
       setPlatformData(newPlatformBase);
       setSelectedTgdbPlatformId('');
+      setPlatformImages([]); // Clear previously loaded images
+      setPlatformImagesBaseUrl(null);
+      setErrorPlatformImages(null);
     }
   }, [isOpen, initialPlatform]);
+
+  // Effect to fetch platform images when a TGDB platform is selected
+  useEffect(() => {
+    if (selectedTgdbPlatformId && isOpen && !initialPlatform) { // Only for new platforms being added
+      setIsLoadingPlatformImages(true);
+      setErrorPlatformImages(null);
+      setPlatformImages([]); // Clear previous images
+      setPlatformImagesBaseUrl(null);
+
+      fetch(`/api/thegamesdb/platform_images?id=${selectedTgdbPlatformId}`)
+        .then(res => {
+          if (!res.ok) {
+            // Try to parse error JSON from proxy if available
+            return res.json().then(errData => {
+              throw new Error(errData.error || `Failed to fetch images: ${res.statusText}`);
+            }).catch(() => { // Fallback if error response isn't JSON
+              throw new Error(`Failed to fetch images: ${res.statusText} (status ${res.status})`);
+            });
+          }
+          return res.json();
+        })
+        .then((data: TheGamesDBPlatformImagesResponse) => {
+          if (data && data.base_url && Array.isArray(data.images)) {
+            setPlatformImages(data.images);
+            setPlatformImagesBaseUrl(data.base_url.original); // Assuming 'original' is desired
+          } else {
+            // This case should ideally be handled by the proxy and return a proper error or empty array.
+            // If proxy returns 200 OK but unexpected structure, this is a fallback.
+            console.warn("Unexpected data structure for platform images:", data);
+            setPlatformImages([]); // Ensure it's an empty array if data is malformed
+            // Potentially set an error message if base_url is missing but images are present, or vice-versa
+            if (!data.base_url) setErrorPlatformImages("Image base URL missing in response.");
+            else setErrorPlatformImages("Image data is malformed.");
+
+          }
+          setIsLoadingPlatformImages(false);
+        })
+        .catch(err => {
+          console.error("Error fetching platform images:", err);
+          setErrorPlatformImages(err.message || 'Could not load platform images.');
+          setIsLoadingPlatformImages(false);
+        });
+    } else if (!selectedTgdbPlatformId) {
+      // Clear images if no platform is selected (e.g., user deselects or form resets)
+      setPlatformImages([]);
+      setPlatformImagesBaseUrl(null);
+      setErrorPlatformImages(null);
+    }
+  }, [selectedTgdbPlatformId, isOpen, initialPlatform]);
 
   const handleUserIconUrlChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setPlatformData(prev => ({ ...prev, userIconUrl: e.target.value }));
@@ -86,22 +141,22 @@ export const PlatformForm: React.FC<PlatformFormProps> = ({ isOpen, onClose, onS
 
   const handleTgdbPlatformSelect = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const selectedId = e.target.value;
-    setSelectedTgdbPlatformId(selectedId);
+    setSelectedTgdbPlatformId(selectedId); // This will trigger the useEffect above to fetch images
     const tgdbPlatform = availableTgdbPlatforms.find(p => p.id.toString() === selectedId);
 
     if (tgdbPlatform) {
       let iconUrlToUse = tgdbPlatform.icon || '';
-      // Basic check if icon is a full URL or needs a base path.
-      // This might need more sophisticated logic based on actual TGDB API response for icons.
       if (tgdbIconBaseUrl && tgdbPlatform.icon && !tgdbPlatform.icon.startsWith('http')) {
         iconUrlToUse = `${tgdbIconBaseUrl.replace(/\/$/, '')}/${tgdbPlatform.icon.replace(/^\//, '')}`;
       }
-
       setPlatformData({
-        ...tgdbPlatform, // Spread all fields from selected TGDB platform
-        id: tgdbPlatform.id, // Ensure ID is the numeric one from TGDB
-        userIconUrl: iconUrlToUse, // Pre-fill userIconUrl from TGDB's icon
+        ...tgdbPlatform,
+        id: tgdbPlatform.id,
+        userIconUrl: iconUrlToUse, // Default icon, will be overridden if user selects from platformImages
       });
+    } else {
+      // If user deselects (e.g. chooses placeholder "-- Choose a platform --")
+      setPlatformData(newPlatformBase); // Reset to base, userIconUrl will be empty
     }
   };
 
@@ -190,6 +245,48 @@ export const PlatformForm: React.FC<PlatformFormProps> = ({ isOpen, onClose, onS
                 onChange={handleUserIconUrlChange}
                 placeholder="https://example.com/icon.png"
             />
+        )}
+
+        {/* Section for selecting from fetched TheGamesDB images - only for new platforms */}
+        {!initialPlatform && selectedTgdbPlatformId && (
+          <div className="mt-4 pt-4 border-t border-neutral-700">
+            <h4 className="text-sm font-medium text-neutral-300 mb-2">Choose Platform Image (from TheGamesDB)</h4>
+            {isLoadingPlatformImages && <p className="text-neutral-400">Loading images...</p>}
+            {errorPlatformImages && <p className="text-red-500">Error: {errorPlatformImages}</p>}
+            {!isLoadingPlatformImages && !errorPlatformImages && platformImages.length === 0 && selectedTgdbPlatformId && (
+              <p className="text-neutral-500">No additional images found for this platform on TheGamesDB, or selection is still pending.</p>
+            )}
+            {platformImagesBaseUrl && platformImages.length > 0 && (
+              <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 gap-3 max-h-60 overflow-y-auto p-1 bg-neutral-800 rounded-md">
+                {platformImages.map(image => {
+                  const fullImageUrl = `${platformImagesBaseUrl.replace(/\/$/, '')}/${image.filename.replace(/^\//, '')}`;
+                  const isSelected = platformData.userIconUrl === fullImageUrl;
+                  return (
+                    <button
+                      type="button"
+                      key={image.id}
+                      onClick={() => {
+                        setPlatformData(prev => ({ ...prev, userIconUrl: fullImageUrl }));
+                      }}
+                      className={`relative aspect-video rounded-md overflow-hidden border-2 transition-all
+                                  ${isSelected ? 'border-primary ring-2 ring-primary' : 'border-neutral-600 hover:border-primary-light focus:border-primary-light'}
+                                  focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-neutral-900`}
+                      aria-label={`Select image ${image.filename} of type ${image.type}`}
+                    >
+                      <img
+                        src={fullImageUrl}
+                        alt={`Platform image ${image.filename} (${image.type})`}
+                        className="w-full h-full object-contain bg-neutral-700" // object-contain is better for varying aspect ratios
+                      />
+                      <div className="absolute bottom-0 left-0 right-0 bg-black/70 text-white text-xs p-1 truncate" title={image.type}>
+                        {image.type}
+                      </div>
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+          </div>
         )}
 
         {/* Display other TGDB info if available and a platform is selected (for new platforms) or when editing */}

--- a/types.ts
+++ b/types.ts
@@ -49,3 +49,24 @@ export interface ApiKeyEntry {
 }
 
 export type NavView = 'games' | 'platforms' | 'scan' | 'apikeys';
+
+// Added for TheGamesDB Platform Images API
+export interface TheGamesDBImage {
+  id: number;
+  type: 'fanart' | 'banner' | 'boxart' | string; // Allow other types from API
+  filename: string;
+  // side?: string; // e.g., "front", "back" for boxart
+  // resolution?: string; // e.g., "1920x1080"
+}
+
+export interface TheGamesDBPlatformImagesResponse {
+  base_url: {
+    original: string;
+    small?: string;
+    thumb?: string;
+    cropped_center_thumb?: string;
+    medium?: string;
+    large?: string;
+  };
+  images: TheGamesDBImage[];
+}


### PR DESCRIPTION
When adding a new platform, after selecting a platform from TheGamesDB, the user is now presented with a selection of images (fanart, banner, boxart) for that specific platform.

Clicking on one of these images updates the 'Custom Icon URL' field, allowing the user to choose a more specific visual representation for the platform beyond the default icon.

Changes include:
- Added `/api/thegamesdb/platform_images` endpoint to the proxy server.
- Updated `PlatformForm.tsx` to fetch and display these images.
- Added new types for TheGamesDB image API responses.
- Ensured loading and error states are handled during image fetching.