### PR TITLE
Feat: Sort TheGamesDB platform dropdown alphabetically

### DIFF
--- a/components/PlatformForm.tsx
+++ b/components/PlatformForm.tsx
@@ -49,7 +49,10 @@ export const PlatformForm: React.FC<PlatformFormProps> = ({ isOpen, onClose, onS
         })
         .then((responseData: { platforms: Platform[], base_image_url?: string | null }) => {
             if (responseData && Array.isArray(responseData.platforms)) {
-                setAvailableTgdbPlatforms(responseData.platforms);
+                const sortedPlatforms = responseData.platforms.sort((a, b) =>
+                    a.name.toLowerCase().localeCompare(b.name.toLowerCase())
+                );
+                setAvailableTgdbPlatforms(sortedPlatforms);
                 if (responseData.base_image_url) {
                     setTgdbIconBaseUrl(responseData.base_image_url);
                     console.log("PlatformForm: Received base_image_url:", responseData.base_image_url);


### PR DESCRIPTION
When adding a new platform, the list of available platforms fetched from TheGamesDB and displayed in the 'Select Platform from TheGamesDB' _dropdown in PlatformForm.tsx is now sorted alphabetically (A-Z, case-insensitive) by platform name.

This improves usability by making it easier for users to locate a specific platform in the potentially long list.