### PR TITLE
refactor: Align platform editing with local data authority and option…

### DIFF
--- a/design.txt
+++ b/design.txt
@@ -1,0 +1,18 @@
+# Design Goals
+
+## Platform Management
+
+The primary goal for platform management is to streamline the initial setup and ongoing maintenance of gaming platforms within the application, balancing automation with user control.
+
+1.  **Easy Initial Setup:** When a new platform is added, the system should fetch as much information as possible from TheGamesDB (e.g., name, overview, developer, manufacturer, available icons/images) to populate the local record automatically. This minimizes manual data entry and allows users to quickly get started.
+2.  **Local Data Authority with Optional Online Refresh:**
+    *   Once a platform is created, the locally stored data is considered the primary source of truth for that platform's details (except for its unique TheGamesDB ID, which is immutable).
+    *   Users can manually edit all local fields (e.g., name, overview, custom icon URL) at any time.
+    *   When editing an existing platform, users should have an explicit option (e.g., a "Refresh from TheGamesDB" button) to fetch the latest metadata for that platform from TheGamesDB. This allows users to update their local record with any new or changed information from the online database *at their discretion*. This refresh should update relevant TGDB-sourced fields but should not automatically overwrite user-customized fields like a manually set icon URL without clear user intent.
+3.  **Flexible Icon Management:** Users should be able to easily set a platform's icon by:
+    *   Selecting from a list of official images/icons fetched from TheGamesDB.
+    *   Providing a URL to a custom image.
+    The chosen icon is stored locally.
+4.  **Automation for Game Association (Future Goal Context):** The platform setup should seamlessly lead into game management. For instance, after a platform (e.g., C64) is configured, users should be able to scan ROM directories, with the system attempting to identify games (using TheGamesDB, AI, or other methods) and associate them with the correct platform, again minimizing manual effort.
+
+This approach ensures a quick, automated initial setup, followed by flexible local management, with the ability to pull in external updates when desired by the user.Tool output for `create_file_with_block`:


### PR DESCRIPTION
…al TGDB refresh

This commit refactors the platform editing functionality to prioritize local data, while providing an explicit option for users to refresh platform metadata from TheGamesDB. This aligns with 'Option C' discussed.

Key changes in `components/PlatformForm.tsx`:
- Platform edit form now loads initial data directly from the locally stored `initialPlatform` object. Automatic fetching of full TGDB details on form load has been removed.
- Added a "Refresh Details from TheGamesDB" button. When clicked, this button fetches the latest metadata (name, overview, developer, etc.) from TheGamesDB for the current platform and updates the form fields.
  - A user-set `userIconUrl` is preserved during this refresh. If no custom icon was set and TGDB provides one, the TGDB icon is adopted.
- Fetching of TheGamesDB *images* for icon selection still occurs when the edit form is opened, allowing users to choose from these images or provide a manual URL for the icon.
- `handleSubmit` saves the current data present in the form, including any manual edits, refreshed data (if refresh was used and saved), and the selected icon.

Added `design.txt` to outline the design goals for platform management, emphasizing easy initial setup via TGDB and flexible local control with optional online data refresh.

Note: The "Refresh Details from TheGamesDB" functionality relies on a backend endpoint `/api/thegamesdb/platform_details?id=<PLATFORM_ID>` to be implemented.