### PR TITLE
FIX: Remove unused apiKeys reference in App.tsx

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -220,8 +220,8 @@ const AppContent: React.FC = () => {
     });
   }, []);
 
-  const theGamesDbApiKey = apiKeys ? (apiKeys.find(k => k.id === THEGAMESDB_API_KEY_ID)?.apiKey || "") : "";
-  const geminiApiKey = apiKeys ? (apiKeys.find(k => k.id === GEMINI_API_KEY_ID)?.apiKey || "") : "";
+  // const theGamesDbApiKey = apiKeys ? (apiKeys.find(k => k.id === THEGAMESDB_API_KEY_ID)?.apiKey || "") : ""; // REMOVED
+  // const geminiApiKey = apiKeys ? (apiKeys.find(k => k.id === GEMINI_API_KEY_ID)?.apiKey || "") : ""; // REMOVED
 
   // Helper function to save data to backend
   const saveDataToBackend = async (endpoint: string, data: any, entityName: string) => {


### PR DESCRIPTION
- Removed dangling references to the old `apiKeys` state variable that were used to derive `theGamesDbApiKey` and `geminiApiKey`.
- These variables are no longer needed as API key handling is fully server-side and components do not receive these keys as props.

This corrects a ReferenceError that occurred after refactoring API key management.