### PR TITLE
FIX: Correct button disable state in GameForm

### DIFF
--- a/components/GameForm.tsx
+++ b/components/GameForm.tsx
@@ -359,7 +359,7 @@ export const GameForm: React.FC<GameFormProps> = ({
             <Button 
                 type="button" 
                 onClick={handleFetchFromGamesDB} 
-                disabled={!theGamesDbApiKey || isFetchingDB || isGeneratingDesc || !gameData.title}
+                disabled={isFetchingDB || isGeneratingDesc || !gameData.title}
                 leftIcon={isFetchingDB ? <SpinnerIcon className="w-4 h-4" /> : <CloudDownloadIcon className="w-4 h-4"/>}
                 size="md"
                 variant="secondary"
@@ -409,7 +409,7 @@ export const GameForm: React.FC<GameFormProps> = ({
             <Button 
                 type="button" 
                 onClick={handleGenerateDescription}
-                disabled={!geminiApiKey || isGeneratingDesc || isFetchingDB || !gameData.title}
+                disabled={isGeneratingDesc || isFetchingDB || !gameData.title}
                 leftIcon={isGeneratingDesc ? <SpinnerIcon className="w-4 h-4" /> : <SparklesIcon className="w-4 h-4"/>}
                 size="md"
                 variant="secondary"


### PR DESCRIPTION
- Removed checks for non-existent API key props from the `disabled` attribute of the 'Fetch Info' and 'Generate' buttons in GameForm.tsx.
- Buttons are now only disabled if a request is already in progress or if the game title is empty.

This fixes an issue where the buttons were incorrectly greyed out due to the earlier refactoring of API key management.