### PR TITLE
FIX: Remove client-side API key checks in GameForm

### DIFF
--- a/components/GameForm.tsx
+++ b/components/GameForm.tsx
@@ -131,10 +131,7 @@ export const GameForm: React.FC<GameFormProps> = ({
   };
 
   const handleFetchFromGamesDB = async () => {
-    if (!theGamesDbApiKey) {
-      setApiError("TheGamesDB API key is not configured.");
-      return;
-    }
+    // Removed client-side API key check: if (!theGamesDbApiKey) { ... }
     if (!gameData.title) {
       setApiError("Please enter a game title to fetch information.");
       return;
@@ -194,10 +191,7 @@ export const GameForm: React.FC<GameFormProps> = ({
   };
 
   const handleGenerateDescription = async () => {
-    if (!geminiApiKey) {
-      setApiError("Gemini API key is not configured.");
-      return;
-    }
+    // Removed client-side API key check: if (!geminiApiKey) { ... }
     if (!gameData.title) {
       setApiError("Please enter a game title to generate a description.");
       return;


### PR DESCRIPTION
- Removed redundant client-side checks for API key presence within the `handleFetchFromGamesDB` and `handleGenerateDescription` functions in `components/GameForm.tsx`.
- These checks were causing incorrect error messages as the API keys are no longer passed as props to this component.
- Server-side validation is now solely responsible for API key checks.