### PR TITLE
Feat: Add folder browser to Scan ROMs page

### DIFF
--- a/components/FolderBrowser.tsx
+++ b/components/FolderBrowser.tsx
@@ -1,0 +1,135 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { Button } from './Button';
+import { DEFAULT_ROM_FOLDER } from '../constants';
+
+interface FileSystemItem {
+  name: string;
+  isDirectory: boolean;
+  path: string;
+}
+
+interface FolderBrowserProps {
+  initialPath?: string;
+  onPathSelected: (path: string) => void;
+  onCancel?: () => void;
+}
+
+export const FolderBrowser: React.FC<FolderBrowserProps> = ({
+  initialPath,
+  onPathSelected,
+  onCancel,
+}) => {
+  const [currentPath, setCurrentPath] = useState<string>(initialPath || DEFAULT_ROM_FOLDER || '');
+  const [parentPath, setParentPath] = useState<string | null>(null);
+  const [items, setItems] = useState<FileSystemItem[]>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchDirectoryContents = useCallback(async (pathToList: string) => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const encodedPath = encodeURIComponent(pathToList);
+      const response = await fetch(`/api/fs/list?path=${encodedPath}`);
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({ error: 'Failed to parse error response from server.' }));
+        throw new Error(errorData.error || `Failed to list directory: ${response.status}`);
+      }
+      const data = await response.json();
+      setCurrentPath(data.currentPath);
+      setParentPath(data.parentPath);
+      setItems(data.items);
+    } catch (err: any) {
+      setError(err.message || 'An unknown error occurred.');
+    } finally {
+      setIsLoading(false);
+    }
+  }, []); // Empty dependency array for useCallback as it doesn't depend on props/state from this scope
+
+  useEffect(() => {
+    // Fetch initial directory contents based on the initial currentPath
+    fetchDirectoryContents(currentPath);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fetchDirectoryContents]); // fetchDirectoryContents is stable due to useCallback with empty deps.
+                               // currentPath is intentionally omitted to only run on initial mount based on initial `currentPath` state.
+
+  const handleNavigate = (newPath: string) => {
+    if (newPath) {
+      fetchDirectoryContents(newPath);
+    }
+  };
+
+  const handleSelectItem = (item: FileSystemItem) => {
+    if (item.isDirectory) {
+      handleNavigate(item.path);
+    }
+  };
+
+  const handleGoUp = () => {
+    if (parentPath) {
+      handleNavigate(parentPath);
+    }
+  };
+
+  const handleSelectCurrentFolder = () => {
+    onPathSelected(currentPath);
+  };
+
+  return (
+    <div className="p-4 bg-neutral-800 text-white rounded-lg shadow-lg max-w-2xl mx-auto my-4 border border-neutral-700">
+      <h3 className="text-xl font-semibold mb-3 text-primary">Browse for Folder</h3>
+
+      <div className="mb-3 p-2 bg-neutral-700 rounded">
+        <p className="text-xs text-neutral-400">Current Path:</p>
+        <p className="font-mono text-neutral-200 break-all">{currentPath}</p>
+      </div>
+
+      {error && <div className="mb-3 p-2 bg-red-800/80 text-red-100 rounded text-sm border border-red-700">{error}</div>}
+
+      <div className="flex flex-wrap gap-2 mb-3">
+        <Button onClick={handleGoUp} disabled={isLoading || !parentPath} className="bg-neutral-600 hover:bg-neutral-500">
+          {/* Icon for Go Up could be added here */}
+          Go Up
+        </Button>
+        <Button onClick={handleSelectCurrentFolder} disabled={isLoading || !!error} className="bg-green-600 hover:bg-green-500 flex-grow">
+          {/* Icon for Select could be added here */}
+          Select This Folder
+        </Button>
+        {onCancel && (
+          <Button onClick={onCancel} disabled={isLoading} className="bg-red-600 hover:bg-red-500">
+            {/* Icon for Cancel could be added here */}
+            Cancel
+          </Button>
+        )}
+      </div>
+
+      {isLoading && <div className="text-center p-4 text-neutral-400">Loading directory...</div>}
+
+      {!isLoading && !error && items.length === 0 && (
+        <div className="text-center p-4 text-neutral-500">This folder is empty or inaccessible.</div>
+      )}
+
+      {!isLoading && !error && items.length > 0 && (
+        <ul className="h-64 overflow-y-auto border border-neutral-700 rounded bg-neutral-850 p-2 space-y-1">
+          {items.map((item) => (
+            <li key={item.name}>
+              <button
+                onClick={() => handleSelectItem(item)}
+                className={`w-full text-left p-2 rounded hover:bg-neutral-700 focus:outline-none focus:bg-neutral-600 transition-colors duration-150 flex items-center space-x-2 ${
+                  item.isDirectory ? 'font-semibold text-sky-300 hover:text-sky-200' : 'text-neutral-300 hover:text-neutral-100'
+                }`}
+                title={item.path}
+              >
+                <span className="text-lg">{item.isDirectory ? '📁' : '📄'}</span>
+                <span>{item.name}</span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+// Ensure Button.tsx exists in components/ and DEFAULT_ROM_FOLDER in constants.ts
+// Basic styling uses Tailwind CSS classes.

--- a/pages/ScanRomsView.tsx
+++ b/pages/ScanRomsView.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Button } from '../components/Button';
 import { Select } from '../components/Select';
 import { Input } from '../components/Input';
+import { FolderBrowser } from '../components/FolderBrowser';
 import { Platform, Game } from '../types';
 import { DEFAULT_ROM_FOLDER } from '../constants';
 
@@ -32,6 +33,7 @@ interface ScanRomsViewProps {
 export const ScanRomsView: React.FC<ScanRomsViewProps> = ({ platforms, onAddGames }) => {
   const [selectedPlatformId, setSelectedPlatformId] = useState<string>('');
   const [romsPath, setRomsPath] = useState<string>(DEFAULT_ROM_FOLDER);
+  const [isFolderBrowserVisible, setIsFolderBrowserVisible] = useState<boolean>(false);
 
   // Stage 1: Raw scanned files
   const [scannedRoms, setScannedRoms] = useState<ScannedRomFile[]>([]);
@@ -292,13 +294,28 @@ export const ScanRomsView: React.FC<ScanRomsViewProps> = ({ platforms, onAddGame
             disabled={isLoading}
           />
         )}
-        <Input
-          label="2. ROMs Folder Path" type="text" value={romsPath} onChange={(e) => setRomsPath(e.target.value)}
-          placeholder="e.g., /Users/username/roms/snes or C:\\ROMs\\SNES" className="w-full"
-          labelClassName="text-neutral-300 text-lg" inputClassName="bg-neutral-700 border-neutral-600 text-white focus:ring-primary focus:border-primary"
-          helpText={`Default: ${DEFAULT_ROM_FOLDER}. Provide the full local path to the directory containing ROM files for ${currentPlatformName}.`}
-          disabled={isLoading || !selectedPlatformId}
-        />
+        <div>
+          <label className="text-neutral-300 text-lg mb-1 block">2. ROMs Folder Path</label>
+          <div className="flex space-x-2 items-end">
+            <Input
+              type="text" value={romsPath} onChange={(e) => setRomsPath(e.target.value)}
+              placeholder="e.g., /Users/username/roms/snes or C:\\ROMs\\SNES"
+              className="w-full" // Occupies available width
+              inputClassName="bg-neutral-700 border-neutral-600 text-white focus:ring-primary focus:border-primary"
+              disabled={isLoading || !selectedPlatformId}
+              // Removed helpText from here to place it after the div
+            />
+            <Button
+              onClick={() => setIsFolderBrowserVisible(true)}
+              className="bg-neutral-600 hover:bg-neutral-500 text-white py-2.5 px-4 rounded-md whitespace-nowrap mb-[1px]" // Adjusted for alignment with typical Input height
+              disabled={isLoading || !selectedPlatformId || platforms.length === 0}
+              title="Browse for folder"
+            >
+              Browse...
+            </Button>
+          </div>
+          <p className="text-xs text-neutral-500 mt-1">{`Default: ${DEFAULT_ROM_FOLDER}. Provide the full local path to the directory containing ROM files for ${currentPlatformName}.`}</p>
+        </div>
         <Button
           onClick={handleScan} disabled={!selectedPlatformId || isLoading || platforms.length === 0}
           className="w-full bg-primary hover:bg-primary-dark text-white font-semibold py-3 px-6 rounded-lg shadow-md transition duration-150 ease-in-out disabled:opacity-60 disabled:cursor-not-allowed flex items-center justify-center space-x-2"
@@ -307,6 +324,19 @@ export const ScanRomsView: React.FC<ScanRomsViewProps> = ({ platforms, onAddGame
         </Button>
         {scanError && <p className="text-sm text-red-400 bg-red-900/30 p-3 rounded-md text-center">{scanError}</p>}
       </section>
+
+      {isFolderBrowserVisible && (
+        <section className="my-4 p-4 md:p-6 border border-neutral-700 rounded-lg bg-neutral-850 shadow-xl max-w-3xl mx-auto">
+          <FolderBrowser
+            initialPath={romsPath}
+            onPathSelected={(selectedPath) => {
+              setRomsPath(selectedPath);
+              setIsFolderBrowserVisible(false);
+            }}
+            onCancel={() => setIsFolderBrowserVisible(false)}
+          />
+        </section>
+      )}
 
       {/* Section for Scanned ROMs (before enrichment OR if enrichment is skipped/failed) */}
       {!showingEnrichedResults && scannedRoms.length > 0 && (


### PR DESCRIPTION
- I've implemented a new API endpoint `/api/fs/list` in `server/proxy-server.js` to securely list directory contents. This endpoint allows navigation within a configured base path (defaults to ROMS_BASE_DIRECTORY or your home directory).
- I've added a new React component `components/FolderBrowser.tsx` that uses the API endpoint to provide a UI for directory navigation and selection.
- I've integrated the `FolderBrowser` component into `pages/ScanRomsView.tsx`. A "Browse..." button now allows you to visually select the ROMs folder path instead of typing it manually.
- I've included basic styling and error handling for the folder browser.